### PR TITLE
Allow inserting binary data using the sqlite-utils base64 encoding syntax

### DIFF
--- a/datasette_insert/__init__.py
+++ b/datasette_insert/__init__.py
@@ -77,6 +77,8 @@ async def insert_or_upsert_implementation(request, datasette):
     if isinstance(post_json, dict):
         post_json = [post_json]
 
+    post_json = (sqlite_utils.utils.decode_base64_values(doc) for doc in post_json)
+
     def write_in_thread(conn):
         db = sqlite_utils.Database(conn)
         if not allow_create_table and not db[table].exists():


### PR DESCRIPTION
The sqlite-utils module provides functionality to insert base64-encoded binary data through a particular syntax, as explained here:
https://sqlite-utils.datasette.io/en/stable/cli.html#inserting-binary-data

This commit exposes the same functionality for datasette-insert.